### PR TITLE
Don't re-use API submission connections

### DIFF
--- a/main.go
+++ b/main.go
@@ -184,6 +184,9 @@ func submit() (err error) {
 	log.Debug("sending payload:\n%s", payload)
 
 	req, err := http.NewRequest("POST", "https://metrics-api.librato.com/v1/metrics", bytes.NewBuffer(payload))
+
+	req.Close = true
+
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Force the connection to close to prevent the potential re-use of dead connections.

The AWS ELB service used by Librato can sometimes close the TLS connection but not correctly close the HTTP connection. Some versions of Go don't handle this situation correctly:

https://code.google.com/p/go/issues/detail?id=3514

This issue causes the next submission to fail with an EOF error. This change forces every request to close the connection after use to avoid this issue.
