### PR TITLE
Added counterAsGauge flag for librato compatibility & other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Usage of statsd:
   -debug=false: enable logging of inputs and submissions
   -flush=60: interval at which data is sent to librato (in seconds)
   -percentiles="": comma separated list of percentiles to calculate for timers (eg. "95,99.5")
-  -counterAsGauge=true: submit counters as gauge for Librato compatibility
+  -counterAsGauge=false: submit counters as gauge for Librato compatibility
   -source="": librato api source (LIBRATO_SOURCE)
   -token="": librato api token (LIBRATO_TOKEN)
   -user="": librato api username (LIBRATO_USER)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Usage of statsd:
   -debug=false: enable logging of inputs and submissions
   -flush=60: interval at which data is sent to librato (in seconds)
   -percentiles="": comma separated list of percentiles to calculate for timers (eg. "95,99.5")
+  -counterAsGauge=true: submit counters as gauge for Librato compatibility
   -source="": librato api source (LIBRATO_SOURCE)
   -token="": librato api token (LIBRATO_TOKEN)
   -user="": librato api username (LIBRATO_USER)

--- a/librato.go
+++ b/librato.go
@@ -76,13 +76,21 @@ func submitLibrato() (err error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
+		if resp.StatusCode == 400 {
+			resetAll()
+		}
 		raw, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("%s: %s", resp.Status, string(raw))
 	}
 
+	if *debug {
+		raw, _ := ioutil.ReadAll(resp.Body)
+		log.Printf("%s: %s", resp.Status, string(raw))
+	}
+
 	log.Printf("%d measurements sent to librato\n", m.Count())
 
-	resetTimers()
+	resetAll()
 
 	return
 }

--- a/main.go
+++ b/main.go
@@ -12,15 +12,16 @@ import (
 const VERSION = "1.0.0"
 
 var (
-	address       = flag.String("address", "0.0.0.0:8125", "udp listen address")
-	libratoUser   = flag.String("user", "", "librato api username (LIBRATO_USER)")
-	libratoToken  = flag.String("token", "", "librato api token (LIBRATO_TOKEN)")
-	libratoSource = flag.String("source", "", "librato api source (LIBRATO_SOURCE)")
-	interval      = flag.Int64("flush", 60, "interval at which data is sent to librato (in seconds)")
-	percentiles   = flag.String("percentiles", "", "comma separated list of percentiles to calculate for timers (eg. \"95,99.5\")")
-	proxy         = flag.String("proxy", "", "send metrics to a proxy rather than directly to librato")
-	debug         = flag.Bool("debug", false, "enable logging of inputs and submissions")
-	version       = flag.Bool("version", false, "print version and exit")
+	address        = flag.String("address", "0.0.0.0:8125", "udp listen address")
+	libratoUser    = flag.String("user", "", "librato api username (LIBRATO_USER)")
+	libratoToken   = flag.String("token", "", "librato api token (LIBRATO_TOKEN)")
+	libratoSource  = flag.String("source", "", "librato api source (LIBRATO_SOURCE)")
+	interval       = flag.Int64("flush", 60, "interval at which data is sent to librato (in seconds)")
+	percentiles    = flag.String("percentiles", "", "comma separated list of percentiles to calculate for timers (eg. \"95,99.5\")")
+	proxy          = flag.String("proxy", "", "send metrics to a proxy rather than directly to librato")
+	debug          = flag.Bool("debug", false, "enable logging of inputs and submissions")
+	version        = flag.Bool("version", false, "print version and exit")
+	counterAsGauge = flag.Bool("counterAsGauge", true, "use counters as guage for Librato compatibility")
 )
 
 func monitor() {

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ var (
 	proxy          = flag.String("proxy", "", "send metrics to a proxy rather than directly to librato")
 	debug          = flag.Bool("debug", false, "enable logging of inputs and submissions")
 	version        = flag.Bool("version", false, "print version and exit")
-	counterAsGauge = flag.Bool("counterAsGauge", true, "use counters as guage for Librato compatibility")
+	counterAsGauge = flag.Bool("counterAsGauge", false, "use counters as guage for Librato compatibility")
 )
 
 func monitor() {

--- a/metric.go
+++ b/metric.go
@@ -1,5 +1,7 @@
 package main
 
+import "log"
+
 var (
 	counters = make(map[string]float64)
 	gauges   = make(map[string]float64)
@@ -14,10 +16,20 @@ func init() {
 func readPacket(p packet) {
 	switch p.bucket {
 	case "c":
-		if _, f := counters[p.name]; !f {
-			counters[p.name] = 0.0
+		if *counterAsGauge == true {
+			if _, f := gauges[p.name]; !f {
+				gauges[p.name] = 0.0
+			}
+			gauges[p.name] += p.value
+			if *debug {
+				log.Printf("counter as guage %.1f\n", gauges[p.name])
+			}
+		} else {
+			if _, f := counters[p.name]; !f {
+				counters[p.name] = 0.0
+			}
+			counters[p.name] += p.value
 		}
-		counters[p.name] += p.value
 
 	case "g":
 		gauges[p.name] = p.value


### PR DESCRIPTION
FEATURE: Added a new flag `counterAsGauge` that submits `counter` values as `gauges` to librato
FIX: If response code is 400, log error & reset counters to prevent repeated submission of data.
FIX: On submit of measures, resetting all buckets so there's no resubmission.
