### PR TITLE
align timestamps to flush interval

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,15 +12,16 @@ import (
 const VERSION = "1.0.0"
 
 var (
-	address       = flag.String("address", "0.0.0.0:8125", "udp listen address")
-	libratoUser   = flag.String("user", "", "librato api username (LIBRATO_USER)")
-	libratoToken  = flag.String("token", "", "librato api token (LIBRATO_TOKEN)")
-	libratoSource = flag.String("source", "", "librato api source (LIBRATO_SOURCE)")
-	interval      = flag.Int64("flush", 60, "interval at which data is sent to librato (in seconds)")
-	percentiles   = flag.String("percentiles", "", "comma separated list of percentiles to calculate for timers (eg. \"95,99.5\")")
-	proxy         = flag.String("proxy", "", "send metrics to a proxy rather than directly to librato")
-	debug         = flag.Bool("debug", false, "enable logging of inputs and submissions")
-	version       = flag.Bool("version", false, "print version and exit")
+	address        = flag.String("address", "0.0.0.0:8125", "udp listen address")
+	libratoUser    = flag.String("user", "", "librato api username (LIBRATO_USER)")
+	libratoToken   = flag.String("token", "", "librato api token (LIBRATO_TOKEN)")
+	libratoSource  = flag.String("source", "", "librato api source (LIBRATO_SOURCE)")
+	interval       = flag.Int64("flush", 60, "interval at which data is sent to librato (in seconds)")
+	alignTimestamp = flag.Bool("allign-timestamp", false, "align metrics timestamps with flush intervals")
+	percentiles    = flag.String("percentiles", "", "comma separated list of percentiles to calculate for timers (eg. \"95,99.5\")")
+	proxy          = flag.String("proxy", "", "send metrics to a proxy rather than directly to librato")
+	debug          = flag.Bool("debug", false, "enable logging of inputs and submissions")
+	version        = flag.Bool("version", false, "print version and exit")
 )
 
 func monitor() {


### PR DESCRIPTION
* useful, if running on multiple servers
* e.g. interval = 60 => all metrics will be reported with full minute timestamps on all servers